### PR TITLE
remove heading art by directly rendering announcements

### DIFF
--- a/frontend/src/components/announcementSection/announcementCard.tsx
+++ b/frontend/src/components/announcementSection/announcementCard.tsx
@@ -27,6 +27,6 @@ export default class AnnouncementCard extends BaseCard<Announcement, Announcemen
     }
 
     render() {
-        return this.renderCard(this.renderAnnouncement());
+        return this.renderAnnouncement();
     }
 }

--- a/frontend/src/shared/globalStyles/global.css
+++ b/frontend/src/shared/globalStyles/global.css
@@ -49,6 +49,7 @@
 }
 
 .notice-content {
+    margin-top: 2vw;
     padding: 2rem;
     font-size: 20px;
     text-align: center;


### PR DESCRIPTION
Looks like this:
![image](https://user-images.githubusercontent.com/6146988/107613487-472d9680-6bfd-11eb-8725-d2701f75bed9.png)
